### PR TITLE
Add ERC20 and Ether support

### DIFF
--- a/loom_js_test/package.json
+++ b/loom_js_test/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "bn.js": "^4.11.8",
     "ethereumjs-util": "^5.2.0",
-    "loom-js": "1.16.1",
+    "loom-js": "loomnetwork/loom-js#update-abi",
     "rlp": "^2.1.0",
     "web3": "^1.0.0-beta.34"
   },

--- a/loom_js_test/package.json
+++ b/loom_js_test/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "bn.js": "^4.11.8",
     "ethereumjs-util": "^5.2.0",
-    "loom-js": "loomnetwork/loom-js#update-abi",
+    "loom-js": "1.16.2",
     "rlp": "^2.1.0",
     "web3": "^1.0.0-beta.34"
   },

--- a/loom_js_test/yarn.lock
+++ b/loom_js_test/yarn.lock
@@ -4425,9 +4425,9 @@ long@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
-loom-js@1.16.1:
+loom-js@loomnetwork/loom-js#update-abi:
   version "1.16.1"
-  resolved "https://registry.yarnpkg.com/loom-js/-/loom-js-1.16.1.tgz#8da659def01a079ff866e942feede1523c0368a1"
+  resolved "https://codeload.github.com/loomnetwork/loom-js/tar.gz/7cf1f6c1b3de82a07c12d734485b4266222d6357"
   dependencies:
     axios "^0.18.0"
     bn.js "^4.11.8"

--- a/loom_js_test/yarn.lock
+++ b/loom_js_test/yarn.lock
@@ -3197,8 +3197,8 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.0.4"
 
 follow-redirects@^1.3.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.2.tgz#5a9d80e0165957e5ef0c1210678fc5c4acb9fb03"
   dependencies:
     debug "^3.1.0"
 
@@ -3486,8 +3486,8 @@ globby@^8.0.1:
     slash "^1.0.0"
 
 google-protobuf@3.6:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.0.tgz#e2bafb00c20a8734174d8f89e0a842709e2ceed0"
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.1.tgz#7ef58e2bea137a93cdaf5cfd5afa5f6abdd92025"
 
 got@7.1.0, got@^7.0.0, got@^7.1.0:
   version "7.1.0"
@@ -4425,9 +4425,9 @@ long@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
-loom-js@loomnetwork/loom-js#update-abi:
-  version "1.16.1"
-  resolved "https://codeload.github.com/loomnetwork/loom-js/tar.gz/7cf1f6c1b3de82a07c12d734485b4266222d6357"
+loom-js@1.16.2:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/loom-js/-/loom-js-1.16.2.tgz#f228996e2300f12798b51b9a97611cc51a777033"
   dependencies:
     axios "^0.18.0"
     bn.js "^4.11.8"
@@ -5904,8 +5904,8 @@ rlp@^2.0.0, rlp@^2.1.0:
     safe-buffer "^5.1.1"
 
 rpc-websockets@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-4.2.0.tgz#46bcb94c3c471d0f699a4cc44da1d4b03da233de"
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-4.2.6.tgz#a7dcfeb6b52dea252198e080c93c87be796f96f0"
   dependencies:
     assert-args "^1.2.1"
     babel-runtime "^6.26.0"
@@ -7513,8 +7513,8 @@ ws@^3.0.0:
     ultron "~1.1.0"
 
 ws@^5.1.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.1.tgz#37827a0ba772d072a843c3615b0ad38bcdb354eb"
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   dependencies:
     async-limiter "~1.0.0"
 

--- a/loom_test/src/client/token_contract.go
+++ b/loom_test/src/client/token_contract.go
@@ -23,8 +23,8 @@ type TContract struct {
 	transactOpts  *bind.TransactOpts
 }
 
-func (d *TContract) Deposit(tokenID int64) (common.Hash, error) {
-	tx, err := d.tokenContract.DepositToPlasma(d.transactOpts, big.NewInt(int64(tokenID)))
+func (d *TContract) Deposit(tokenID *big.Int) (common.Hash, error) {
+	tx, err := d.tokenContract.DepositToPlasma(d.transactOpts, tokenID)
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -36,12 +36,12 @@ func (d *TContract) Register() error {
 	return err
 }
 
-func (d *TContract) BalanceOf() (int64, error) {
+func (d *TContract) BalanceOf() (*big.Int, error) {
 	bal, err := d.tokenContract.BalanceOf(nil, d.callerAddr)
 	if err != nil {
-		return 0, err
+		return big.NewInt(0), err
 	}
-	return bal.Int64(), nil
+	return bal, nil
 }
 
 func (d *TContract) Account() (*plasma_cash.Account, error) {

--- a/loom_test/src/cmd/challenge_between_demo/main.go
+++ b/loom_test/src/cmd/challenge_between_demo/main.go
@@ -4,6 +4,7 @@ import (
 	"client"
 	"context"
 	"fmt"
+    "math/big"
 	"log"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -39,7 +40,7 @@ func main() {
 	exitIfError(err)
 
 	// Eve deposits a coin
-	txHash := eve.Deposit(11)
+	txHash := eve.Deposit(big.NewInt(11))
 	deposit1, err := eve.RootChain.DepositEventData(txHash)
 	exitIfError(err)
 
@@ -48,7 +49,7 @@ func main() {
 	// Eve sends her plasma coin to Bob
 	coin, err := eve.PlasmaCoin(deposit1.Slot)
 	exitIfError(err)
-	err = eve.SendTransaction(deposit1.Slot, coin.DepositBlockNum, 1, bobAccount.Address)
+	err = eve.SendTransaction(deposit1.Slot, coin.DepositBlockNum, big.NewInt(1), bobAccount.Address)
 	exitIfError(err)
 
 	err = authority.SubmitBlock()
@@ -59,7 +60,7 @@ func main() {
 	// TODO: bob.WatchExits(deposit1.Slot)
 
 	// Eve sends this same plasma coin to Alice
-	err = eve.SendTransaction(deposit1.Slot, coin.DepositBlockNum, 1, aliceAccount.Address)
+	err = eve.SendTransaction(deposit1.Slot, coin.DepositBlockNum, big.NewInt(1), aliceAccount.Address)
 	exitIfError(err)
 
 	err = authority.SubmitBlock()
@@ -112,7 +113,7 @@ func main() {
 	exitIfError(err)
 
 	fmt.Printf("Bob has %d tokens", bobTokensEnd)
-	if !(bobTokensEnd == bobTokensStart+1) {
+	if bobTokensEnd.Cmp(bobTokensStart.Add(bobTokensStart, big.NewInt(1))) != 0 {
 		log.Fatal("END: Bob has incorrect number of tokens")
 	}
 

--- a/loom_test/src/cmd/respond_challenge_before_demo/main.go
+++ b/loom_test/src/cmd/respond_challenge_before_demo/main.go
@@ -4,6 +4,7 @@ import (
 	"client"
 	"context"
 	"fmt"
+    "math/big"
 	"log"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -35,7 +36,7 @@ func main() {
 	exitIfError(err)
 
 	// Trudy deposits a coin
-	txHash := trudy.Deposit(21)
+	txHash := trudy.Deposit(big.NewInt(21))
 	depEvent, err := trudy.RootChain.DepositEventData(txHash)
 	exitIfError(err)
 	depositSlot1 := depEvent.Slot
@@ -54,7 +55,7 @@ func main() {
 	// TODO: Trudy should start watching for exits of depositSlot1
 
 	// Trudy sends her coin to Dan
-	exitIfError(trudy.SendTransaction(depositSlot1, coin.DepositBlockNum, 1, danAccount.Address))
+	exitIfError(trudy.SendTransaction(depositSlot1, coin.DepositBlockNum, big.NewInt(1), danAccount.Address))
 	exitIfError(authority.SubmitBlock())
 	trudyToDanBlockNum, err := authority.GetBlockNumber()
 	exitIfError(err)
@@ -64,7 +65,7 @@ func main() {
 	coin, err = dan.RootChain.PlasmaCoin(depositSlot1)
 	exitIfError(err)
 	fmt.Println("Dan attempts to exit...")
-	_, err = dan.StartExit(depositSlot1, 0, coin.DepositBlockNum)
+	_, err = dan.StartExit(depositSlot1, big.NewInt(0), coin.DepositBlockNum)
 	exitIfError(err)
 	exitIfError(authority.SubmitBlock())
 
@@ -72,7 +73,7 @@ func main() {
 	// TODO: Dan should start watching for challenges of depositSlot1
 
 	fmt.Println("Trudy attempts to challenge Dan's exit...")
-	challengeTxHash, err := trudy.ChallengeBefore(depositSlot1, 0, coin.DepositBlockNum)
+	challengeTxHash, err := trudy.ChallengeBefore(depositSlot1, big.NewInt(0), coin.DepositBlockNum)
 	exitIfError(err)
 
 	challengedExitEvent, err := trudy.RootChain.ChallengedExitEventData(common.BytesToHash(challengeTxHash))
@@ -108,7 +109,7 @@ func main() {
 	danTokensEnd, err := dan.TokenContract.BalanceOf()
 	exitIfError(err)
 	log.Printf("Dan has %v tokens", danTokensEnd)
-	if danTokensEnd != (danTokenStart + 1) {
+	if danTokensEnd.Cmp(danTokenStart.Add(danTokenStart, big.NewInt(1))) != 0 {
 		log.Fatal("END: Dan has incorrect number of tokens")
 	}
 

--- a/server/contracts/Core/ERC20Receiver.sol
+++ b/server/contracts/Core/ERC20Receiver.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.24;
+
+/**
+ * @title ERC20 token receiver interface
+ * @dev Interface for any contract that wants to support safeTransfers
+ *  from ERC20 asset contracts.
+ */
+
+contract ERC20Receiver {
+    /**
+     * @dev Magic value to be returned upon successful reception of an NFT
+     *  Equals to `bytes4(keccak256("onERC20Received(address,uint256)"))`,
+     *  which can be also obtained as `ERC20Receiver(0).onERC20Received.selector`
+     */
+    bytes4 constant ERC20_RECEIVED = 0xbc04f0af;
+
+    function onERC20Received(address _from, uint256 amount) public returns(bytes4);
+
+}

--- a/server/contracts/Core/ERC20Receiver.sol
+++ b/server/contracts/Core/ERC20Receiver.sol
@@ -3,17 +3,17 @@ pragma solidity ^0.4.24;
 /**
  * @title ERC20 token receiver interface
  * @dev Interface for any contract that wants to support safeTransfers
- *  from ERC20 asset contracts.
+ *  from ERC20 contracts.
  */
 
 contract ERC20Receiver {
     /**
-     * @dev Magic value to be returned upon successful reception of an NFT
-     *  Equals to `bytes4(keccak256("onERC20Received(address,uint256)"))`,
+     * @dev Magic value to be returned upon successful reception of an amount of ERC20 tokens
+     *  Equals to `bytes4(keccak256("onERC20Received(address,uint256,bytes)"))`,
      *  which can be also obtained as `ERC20Receiver(0).onERC20Received.selector`
      */
-    bytes4 constant ERC20_RECEIVED = 0xbc04f0af;
+    bytes4 constant ERC20_RECEIVED = 0x65d83056;
 
-    function onERC20Received(address _from, uint256 amount) public returns(bytes4);
+    function onERC20Received(address _from, uint256 amount, bytes data) public returns(bytes4);
 
 }

--- a/server/contracts/Core/ExtendedERC20.sol
+++ b/server/contracts/Core/ExtendedERC20.sol
@@ -12,19 +12,23 @@ contract ExtendedERC20 is StandardToken {
     bytes4 constant ERC20_RECEIVED = 0xbc04f0af;
     using AddressUtils for address;
 
-    function safeTransferAndCall(address _to, uint256 amount) public {
-        transfer(_to, amount);
+    function safeTransferAndCall(address _to, uint256 _amount) public {
+        safeTransferAndCall(_to, _amount, "");
+      }
+
+    function safeTransferAndCall(address _to, uint256 _amount, bytes _data) public {
+        transfer(_to, _amount);
         require(
-            checkAndCallSafeTransfer(msg.sender, _to, amount),
+            checkAndCallSafeTransfer(msg.sender, _to, _amount, _data),
            "Sent to a contract which is not an ERC20 receiver"
         );
     }
 
-    function checkAndCallSafeTransfer(address _from, address _to, uint256 amount) internal returns (bool) {
+    function checkAndCallSafeTransfer(address _from, address _to, uint256 _amount, bytes _data) internal returns (bool) {
         if (!_to.isContract()) {
             return true;
         }
-        bytes4 retval = ERC20Receiver(_to).onERC20Received(_from, amount);
+        bytes4 retval = ERC20Receiver(_to).onERC20Received(_from, _amount, _data);
         return(retval == ERC20_RECEIVED);
     }
 

--- a/server/contracts/Core/ExtendedERC20.sol
+++ b/server/contracts/Core/ExtendedERC20.sol
@@ -9,7 +9,7 @@ import "./ERC20Receiver.sol";
 
 contract ExtendedERC20 is StandardToken {
 
-    bytes4 constant ERC20_RECEIVED = 0xbc04f0af;
+    bytes4 constant ERC20_RECEIVED = 0x65d83056;
     using AddressUtils for address;
 
     function safeTransferAndCall(address _to, uint256 _amount) public {

--- a/server/contracts/Core/ExtendedERC20.sol
+++ b/server/contracts/Core/ExtendedERC20.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.4.24;
+
+import "openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol";
+import "openzeppelin-solidity/contracts/AddressUtils.sol";
+import "./ERC20Receiver.sol";
+
+// Extension on the StandardToken to also make a call
+// on the receiving contract, ERC721 style.
+
+contract ExtendedERC20 is StandardToken {
+
+    bytes4 constant ERC20_RECEIVED = 0xbc04f0af;
+    using AddressUtils for address;
+
+    function safeTransferAndCall(address _to, uint256 amount) public {
+        transfer(_to, amount);
+        require(
+            checkAndCallSafeTransfer(msg.sender, _to, amount),
+           "Sent to a contract which is not an ERC20 receiver"
+        );
+    }
+
+    function checkAndCallSafeTransfer(address _from, address _to, uint256 amount) internal returns (bool) {
+        if (!_to.isContract()) {
+            return true;
+        }
+        bytes4 retval = ERC20Receiver(_to).onERC20Received(_from, amount);
+        return(retval == ERC20_RECEIVED);
+    }
+
+}

--- a/server/contracts/Core/LoomToken.sol
+++ b/server/contracts/Core/LoomToken.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.24;
+
+import "./ExtendedERC20.sol";
+
+contract LoomToken is ExtendedERC20 {
+    string public name    = "LoomToken";
+    string public symbol  = "LOOM";
+    uint8 public decimals = 18;
+    address plasma;
+
+    // one billion in initial supply
+    uint256 public constant INITIAL_SUPPLY = 1000000000;
+
+    constructor(address _plasma) public {
+        totalSupply_ = INITIAL_SUPPLY * (10 ** uint256(decimals));
+        balances[msg.sender] = totalSupply_;
+        plasma = _plasma;
+    }
+
+    // Additional functions for plasma interaction, influenced from Zeppelin ERC721 Impl.
+
+    function depositToPlasma(uint256 amount) external {
+        safeTransferAndCall(plasma, amount);
+    }
+}

--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -247,7 +247,12 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
     ///            related to `slot`. If the coin is ETH or ERC20 the uid is 0
     /// @param denomination The quantity of a particular coin being deposited
     /// @param mode The type of coin that is being deposited (ETH/ERC721/ERC20)
-    function deposit(address from, uint256 uid, uint256 denomination, Mode mode)
+    function deposit(
+        address from, 
+        uint256 uid, 
+        uint256 denomination, 
+        Mode mode
+    )
         private
     {
         currentBlock = currentBlock.add(1);
@@ -255,7 +260,7 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
 
         // Update state. Leave `exit` empty
         Coin storage coin = coins[slot];
-        coin.uid =  uid;
+        coin.uid = uid;
         coin.contractAddress = msg.sender;
         coin.denomination = denomination;
         coin.depositBlock = currentBlock;
@@ -447,7 +452,7 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
         } else if (c.mode == Mode.ERC721) {
             ERC721(c.contractAddress).safeTransferFrom(address(this), msg.sender, uid);
         } else {
-            revert('Invalid coin mode');
+            revert("Invalid coin mode");
         }
 
         emit Withdrew(msg.sender, c.mode, c.contractAddress, uid, denomination);

--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -717,12 +717,12 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
         deposit(msg.sender, 0, msg.value, Mode.ETH);
     }
 
-    function onERC20Received(address _from, uint256 amount, bytes)
+    function onERC20Received(address _from, uint256 _amount, bytes)
         public
         isTokenApproved(msg.sender)
         returns(bytes4)
     {
-        deposit(_from, 0, amount, Mode.ERC20);
+        deposit(_from, 0, _amount, Mode.ERC20);
         return ERC20_RECEIVED;
     }
 

--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -31,8 +31,10 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
      *                    is included
      * @param denomination Quantity of a particular coin deposited
      * @param from The address of the depositor
+     * @param contractAddress The address of the contract making the deposit
      */
-    event Deposit(uint64 indexed slot, uint256 blockNumber, uint256 denomination, address indexed from);
+    event Deposit(uint64 indexed slot, uint256 blockNumber, uint256 denomination, 
+                  address indexed from, address indexed contractAddress);
 
     /**
      * Event for block submission logging
@@ -44,13 +46,13 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
      */
     event SubmittedBlock(uint256 blockNumber, bytes32 root, uint256 timestamp);
 
-
     /**
      * Event for logging exit starts
      * @param slot The slot of the coin being exited
      * @param owner The user who claims to own the coin being exited
      */
     event StartedExit(uint64 indexed slot, address indexed owner);
+
     /**
      * Event for exit challenge logging
      * @notice This event only fires if `challengeBefore` is called. Other
@@ -60,6 +62,7 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
      * @param txHash The hash of the tx used for the challenge
      */
     event ChallengedExit(uint64 indexed slot, bytes32 txHash);
+
     /**
      * Event for exit response logging
      * @notice This only logs responses to `challengeBefore`, other challenges
@@ -67,6 +70,7 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
      * @param slot The slot of the coin whose challenge was responded to
      */
     event RespondedExitChallenge(uint64 indexed slot);
+
     /**
      * Event for exit finalization logging
      * @param slot The slot of the coin whose exit has been finalized
@@ -80,6 +84,7 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
      * @param amount The bond amount which can now be withdrawn
      */
     event FreedBond(address indexed from, uint256 amount);
+
     /**
      * Event to log the slashing of a bond
      * @param from The address of the user whose bonds have been slashed
@@ -87,6 +92,7 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
      * @param amount The bound amount which has been forfeited
      */
     event SlashedBond(address indexed from, address indexed to, uint256 amount);
+
     /**
      * Event to log the withdrawal of a bond
      * @param from The address of the user who withdrew bonds
@@ -442,7 +448,7 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
         uint256 uid = coins[slot].uid;
         uint256 denomination = coins[slot].denomination;
 
-		// Delete the coin that is being withdrawn
+        // Delete the coin that is being withdrawn
         Coin memory c = coins[slot];
         delete coins[slot];
         if (c.mode == Mode.ETH) {
@@ -462,7 +468,7 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
             uid,
             denomination
         );
-}
+    }
 
     /******************** CHALLENGES ********************/
 

--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -455,7 +455,13 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
             revert("Invalid coin mode");
         }
 
-        emit Withdrew(msg.sender, c.mode, c.contractAddress, uid, denomination);
+        emit Withdrew(
+            msg.sender,
+            c.mode,
+            c.contractAddress,
+            uid,
+            denomination
+        );
 }
 
     /******************** CHALLENGES ********************/
@@ -581,7 +587,16 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
 
     // Check that the challenging transaction has been signed
     // by the attested previous owner of the coin in the exit
-    function checkBetween(uint64 slot, bytes txBytes, uint blockNumber, bytes signature, bytes proof) private view {
+    function checkBetween(
+        uint64 slot,
+        bytes txBytes,
+        uint blockNumber, 
+        bytes signature, 
+        bytes proof
+    ) 
+        private 
+        view 
+    {
         require(
             coins[slot].exit.exitBlock > blockNumber &&
             coins[slot].exit.prevBlock < blockNumber,
@@ -696,7 +711,15 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
         checkTxIncluded(exitingTxData.slot, exitingTxData.hash, blocks[1], exitingTxInclusionProof);
     }
 
-    function checkTxIncluded(uint64 slot, bytes32 txHash, uint256 blockNumber, bytes proof) private view {
+    function checkTxIncluded(
+        uint64 slot, 
+        bytes32 txHash, 
+        uint256 blockNumber,
+        bytes proof
+    ) 
+        private 
+        view 
+    {
         bytes32 root = childChain[blockNumber].root;
 
         if (blockNumber % childBlockInterval != 0) {

--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -1,19 +1,21 @@
 pragma solidity ^0.4.24;
 
-// Zeppelin Imports
+
+// ERC721
 import "openzeppelin-solidity/contracts/token/ERC721/ERC721.sol";
 import "openzeppelin-solidity/contracts/token/ERC721/ERC721Receiver.sol";
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
-// ERC20 Receiver
+// ERC20
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./ERC20Receiver.sol";
 
-
 // Lib deps
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "../Libraries/Transaction/Transaction.sol";
 import "../Libraries/ECVerify.sol";
 import "../Libraries/ChallengeLib.sol";
 
+// SMT and VMC
 import "./SparseMerkleTree.sol";
 import "./ValidatorManagerContract.sol";
 
@@ -30,11 +32,8 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
      * @param denomination Quantity of a particular coin deposited
      * @param from The address of the depositor
      */
-<<<<<<< HEAD
-    event Deposit(uint64 indexed slot, uint256 blockNumber, uint64 denomination, address indexed from, address indexed contractAddress);
-=======
     event Deposit(uint64 indexed slot, uint256 blockNumber, uint256 denomination, address indexed from);
->>>>>>> Add ERC20/ETH Deposits to RootChain
+
     /**
      * Event for block submission logging
      * @notice The event indicates the addition of a new Plasma block
@@ -94,6 +93,17 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
      * @param amount The bond amount which has been withdrawn
      */
     event WithdrewBonds(address indexed from, uint256 amount);
+
+    /**
+     * Event to log the withdrawal of a coin
+     * @param from The address of the user who withdrew bonds
+     * @param mode The type of coin that is being withdrawn (ERC20/ERC721/ETH)
+     * @param contractAddress The contract address where the coin is being withdrawn from
+              is same as `from` when withdrawing a ETH coin
+     * @param uid The uid of the coin being withdrawn if ERC721, else 0
+     * @param denomination The denomination of the coin which has been withdrawn (=1 for ERC721)
+     */
+    event Withdrew(address indexed from, Mode mode, address contractAddress, uint uid, uint denomination);
 
     using SafeMath for uint256;
     using Transaction for bytes;
@@ -424,8 +434,24 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
     /// @param slot The slot of the coin being withdrawn
     function withdraw(uint64 slot) external isState(slot, State.EXITED) {
         require(coins[slot].owner == msg.sender, "You do not own that UTXO");
-        ERC721(coins[slot].contractAddress).safeTransferFrom(address(this), msg.sender, uint256(coins[slot].uid));
-    }
+        uint256 uid = coins[slot].uid;
+        uint256 denomination = coins[slot].denomination;
+
+		// Delete the coin that is being withdrawn
+        Coin memory c = coins[slot];
+        delete coins[slot];
+        if (c.mode == Mode.ETH) {
+            msg.sender.transfer(denomination);
+        } else if (c.mode == Mode.ERC20) {
+            ERC20(c.contractAddress).transfer(msg.sender, denomination);
+        } else if (c.mode == Mode.ERC721) {
+            ERC721(c.contractAddress).safeTransferFrom(address(this), msg.sender, uid);
+        } else {
+            revert('Invalid coin mode');
+        }
+
+        emit Withdrew(msg.sender, c.mode, c.contractAddress, uid, denomination);
+}
 
     /******************** CHALLENGES ********************/
 
@@ -739,15 +765,9 @@ contract RootChain is ERC721Receiver, ERC20Receiver {
             proof);
     }
 
-<<<<<<< HEAD
-    function getPlasmaCoin(uint64 slot) external view returns(uint64, uint256, uint32, address, address, State) {
-        Coin memory c = coins[slot];
-        return (c.uid, c.depositBlock, c.denomination, c.owner, c.contractAddress, c.state);
-=======
     function getPlasmaCoin(uint64 slot) external view returns(uint256, uint256, uint256, address, State, Mode, address) {
         Coin memory c = coins[slot];
         return (c.uid, c.depositBlock, c.denomination, c.owner, c.state, c.mode, c.contractAddress);
->>>>>>> Add ERC20/ETH Deposits to RootChain
     }
 
     function getExit(uint64 slot) external view returns(address, uint256, uint256, State) {

--- a/server/contracts/Libraries/Transaction/Transaction.sol
+++ b/server/contracts/Libraries/Transaction/Transaction.sol
@@ -10,10 +10,10 @@ library Transaction {
 
     struct TX {
         uint64 slot;
-        uint32 denomination; // 2**32 more than enough for NFTs, helps pack in 1 slot
         address owner;
         bytes32 hash;
         uint256 prevBlock;
+        uint256 denomination; 
     }
 
     function getTx(bytes memory txBytes) internal pure returns (TX memory) {
@@ -21,8 +21,8 @@ library Transaction {
         TX memory transaction;
 
         transaction.slot = uint64(rlpTx[0].toUint());
-        transaction.prevBlock = uint256(rlpTx[1].toUint());
-        transaction.denomination = uint32(rlpTx[2].toUint());
+        transaction.prevBlock = rlpTx[1].toUint();
+        transaction.denomination = rlpTx[2].toUint();
         transaction.owner = rlpTx[3].toAddress();
         if (transaction.prevBlock == 0) { // deposit transaction
             transaction.hash = keccak256(abi.encodePacked(transaction.slot));

--- a/server/test/testAllInOne.js
+++ b/server/test/testAllInOne.js
@@ -1,0 +1,112 @@
+const ValidatorManagerContract = artifacts.require("ValidatorManagerContract");
+const LoomToken = artifacts.require("LoomToken");
+const CryptoCards = artifacts.require("CryptoCards");
+const RootChain = artifacts.require("RootChain");
+import {increaseTimeTo, duration} from './helpers/increaseTime'
+import assertRevert from './helpers/assertRevert.js';
+
+const txlib = require('./UTXO.js')
+
+contract("Plasma Cash - All In One", async function(accounts) {
+
+    const t1 = 3600 * 24 * 3; // 3 days later
+    const t2 = 3600 * 24 * 5; // 5 days later
+
+    // Alice registers and has 5 coins, and she deposits 3 of them.
+    const ALICE_INITIAL_COINS = 5;
+    const ALICE_DEPOSITED_COINS = 3;
+    const coins = [1, 2, 3];
+
+    let erc20;
+    let erc721;
+    let plasma;
+    let vmc;
+    let events;
+    let t0;
+
+    let [authority, alice, bob, charlie, dylan, elliot, random_guy, random_guy2, challenger] = accounts;
+
+    const DECIMALS = 10 ** 18;
+    const denominations = [
+        3000 * DECIMALS, 
+        2000 * DECIMALS, 
+        4000 * DECIMALS
+    ];
+
+    const ethers = [
+        web3.toWei(1, 'ether'),
+        web3.toWei(4, 'ether'),
+        web3.toWei(5, 'ether')
+    ];
+
+    beforeEach(async function() {
+        vmc = await ValidatorManagerContract.new({from: authority});
+        plasma = await RootChain.new(vmc.address, {from: authority});
+        erc20 = await LoomToken.new(plasma.address, {from: authority});
+        erc721 = await CryptoCards.new(plasma.address, {from: authority});
+
+        await vmc.toggleToken(erc20.address, {from: authority});
+        await vmc.toggleToken(erc721.address, {from: authority});
+
+        await erc20.transfer(alice, 10000 * DECIMALS, {from: authority});
+        await erc721.register({from: alice});
+
+        for (let i = 0; i < denominations.length; i ++) {
+            await web3.eth.sendTransaction({from: alice, to: plasma.address, value: ethers[i], gas: 200000 });
+            await erc20.depositToPlasma(denominations[i], {from: alice});
+            await erc721.depositToPlasma(coins[i], {from: alice});
+        }
+        assert.equal(await erc20.balanceOf.call(alice), 1000 * DECIMALS);
+        assert.equal(await erc20.balanceOf.call(plasma.address), 9000 * DECIMALS);
+
+        assert.equal(await erc721.balanceOf.call(plasma.address), 3);
+        assert.equal(await erc721.balanceOf.call(alice), 2);
+
+        assert.equal(await web3.eth.getBalance(plasma.address), web3.toWei(10, 'ether'));
+
+        const depositEvent = plasma.Deposit({}, {fromBlock: 0, toBlock: 'latest'});
+        events = await txlib.Promisify(cb => depositEvent.get(cb));
+    });
+
+    describe('Exit of UTXO 2 and 7 (UTXO 7 added at 1000-2000 block interval)', function() {
+		it('Directly after their deposit', async function() {
+			let UTXO = [
+                {'slot': events[0]['args'].slot, 'block': events[0]['args'].blockNumber.toNumber()},
+                {'slot': events[1]['args'].slot, 'block': events[1]['args'].blockNumber.toNumber()},
+                {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()},
+            ]
+
+            let prevBlock = 0;
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                let ret = txlib.createUTXO(aUTXO.slot, prevBlock, alice, alice);
+                let utxo = ret.tx;
+                let sig = ret.sig;
+
+                await plasma.startExit(
+                    aUTXO.slot,
+                    '0x', utxo,
+                    '0x0', '0x0',
+                    sig,
+                    [prevBlock, aUTXO.block],
+                    {'from': alice, 'value': web3.toWei(0.1, 'ether')}
+                );
+            }
+            t0 = (await web3.eth.getBlock('latest')).timestamp;
+            await increaseTimeTo(t0 + t1);
+            await plasma.finalizeExits({from: random_guy2 });
+
+            await increaseTimeTo(t0 + t1 + t2);
+            await plasma.finalizeExits({from: random_guy2 });
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                await plasma.withdraw(aUTXO.slot, {from : alice });
+            }
+
+            // Alice has her coins back.
+            await txlib.withdrawBonds(plasma, alice, 0.3);
+        });
+
+    });
+
+});

--- a/server/test/testAllInOne.js
+++ b/server/test/testAllInOne.js
@@ -68,7 +68,7 @@ contract("Plasma Cash - All In One", async function(accounts) {
         events = await txlib.Promisify(cb => depositEvent.get(cb));
     });
 
-    describe('Exit of UTXO 2 and 7 (UTXO 7 added at 1000-2000 block interval)', function() {
+    describe('Exit of an ERC20, an ERC721 and an ETH coin', function() {
 		it('Directly after their deposit', async function() {
 			let UTXO = [
                 {'slot': events[0]['args'].slot, 'block': events[0]['args'].blockNumber.toNumber()},
@@ -105,6 +105,120 @@ contract("Plasma Cash - All In One", async function(accounts) {
 
             // Alice has her coins back.
             await txlib.withdrawBonds(plasma, alice, 0.3);
+        });
+
+		it('After 1 on chain transaction', async function() {
+			let UTXO = [
+                {'slot': events[0]['args'].slot, 'block': events[0]['args'].blockNumber.toNumber()},
+                {'slot': events[1]['args'].slot, 'block': events[1]['args'].blockNumber.toNumber()},
+                {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()},
+            ]
+
+            let prevBlock = 0;
+            let leaves = [];
+            let txs = [];
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                let tx = txlib.createUTXO(aUTXO.slot, prevBlock, alice, bob);
+                leaves.push(tx.leaf)
+                txs.push(tx)
+            }
+            let tree_1000 = await txlib.submitTransactions(authority, plasma, leaves);
+
+            let exitingBlock = 1000;
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                let prev_tx = txlib.createUTXO(aUTXO.slot, 0, alice, alice).tx;
+                let exiting_tx = txs[i];
+                let utxo = exiting_tx.tx;
+                let sig = exiting_tx.sig;
+                let proof = tree_1000.createMerkleProof(aUTXO.slot);
+
+                await plasma.startExit(
+                    aUTXO.slot,
+                    prev_tx, utxo,
+                    '0x0', proof,
+                    sig,
+                    [aUTXO.block, exitingBlock],
+                    {'from': bob, 'value': web3.toWei(0.1, 'ether')}
+                );
+            }
+            t0 = (await web3.eth.getBlock('latest')).timestamp;
+            await increaseTimeTo(t0 + t1);
+            await plasma.finalizeExits({from: random_guy2 });
+
+
+            await increaseTimeTo(t0 + t1 + t2);
+            await plasma.finalizeExits({from: random_guy2 });
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                await plasma.withdraw(aUTXO.slot, {from : bob });
+            }
+
+            // Alice has her coins back.
+            await txlib.withdrawBonds(plasma, bob, 0.3);
+        });
+
+		it('After 2 on chain transaction', async function() {
+			let UTXO = [
+                {'slot': events[0]['args'].slot, 'block': events[0]['args'].blockNumber.toNumber()},
+                {'slot': events[1]['args'].slot, 'block': events[1]['args'].blockNumber.toNumber()},
+                {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()},
+            ]
+
+            let prevBlock = 0;
+            let leaves = [];
+            let prev_txs = [];
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                let tx = txlib.createUTXO(aUTXO.slot, prevBlock, alice, bob);
+                leaves.push(tx.leaf)
+                prev_txs.push(tx)
+            }
+            let tree_1000 = await txlib.submitTransactions(authority, plasma, leaves);
+
+            prevBlock = 1000;
+            leaves = [];
+            let txs = [];
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                let tx = txlib.createUTXO(aUTXO.slot, prevBlock, bob, charlie);
+                leaves.push(tx.leaf)
+                txs.push(tx)
+            }
+            let tree_2000 = await txlib.submitTransactions(authority, plasma, leaves);
+
+
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                let prev_tx = prev_txs[i];
+                let exiting_tx = txs[i];
+                let prev_tx_proof = tree_1000.createMerkleProof(aUTXO.slot);
+                let exiting_tx_proof = tree_2000.createMerkleProof(aUTXO.slot);
+
+                await plasma.startExit(
+                    aUTXO.slot,
+                    prev_tx.tx, exiting_tx.tx,
+                    prev_tx_proof, exiting_tx_proof,
+                    exiting_tx.sig,
+                    [1000, 2000],
+                    {'from': charlie, 'value': web3.toWei(0.1, 'ether')}
+                );
+            }
+
+            t0 = (await web3.eth.getBlock('latest')).timestamp;
+            await increaseTimeTo(t0 + t1);
+            await plasma.finalizeExits({from: random_guy2 });
+
+            await increaseTimeTo(t0 + t1 + t2);
+            await plasma.finalizeExits({from: random_guy2 });
+            for (let i in UTXO) {
+                let aUTXO = UTXO[i];
+                await plasma.withdraw(aUTXO.slot, {from : charlie });
+            }
+
+            // Alice has her coins back.
+            await txlib.withdrawBonds(plasma, charlie, 0.3);
         });
 
     });


### PR DESCRIPTION
- Adds functionality for supporting ERC20 and Ether tokens in the contracts. 
- Extends ERC20 to be similar to ERC721 In order to make callbacks to the Plasma Contract
- Adds a cooperative exit test for erc20/erc721/ether coins being traded

Depends on https://github.com/loomnetwork/go-loom/pull/95