### PR TITLE
Fix bonds not being freed as required after a successful challengeBefore

### DIFF
--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -355,6 +355,8 @@ contract RootChain is ERC721Receiver {
             // Update coin state & penalize exitor
             coin.state = State.DEPOSITED;
             slashBond(coin.exit.owner, challengers[slot]);
+            freeBond(challengers[slot]);
+
         // otherwise, the exit has not been challenged, or it has been challenged and responded
         } else {
             // Update coin's owner

--- a/server/test/testChallengeBefore.js
+++ b/server/test/testChallengeBefore.js
@@ -100,8 +100,9 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
             assert.equal(await cards.balanceOf.call(elliot), 0);
             assert.equal(await cards.balanceOf.call(plasma.address), 3);
 
-            // On the contrary, his bond must be slashed, and `challenger` must be able to claim it
-            await txlib.withdrawBonds(plasma, challenger, 0.1);
+            // On the contrary, his bond must be slashed, and `challenger` must be able to claim it, 
+            // along with his bond for initiating the challenge
+            await txlib.withdrawBonds(plasma, challenger, 0.2);
         });
 
         it("Alice gives coin to Bob who gives it back to Alice. After some time, an invalid spend of that coin happens. Alice challenges but challenger tries an invalid response", async function() {
@@ -243,6 +244,8 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
             assert.equal((await cards.balanceOf.call(elliot)).toNumber(), 1);
             assert.equal((await cards.balanceOf.call(plasma.address)).toNumber(), 2);
 
+            // On the contrary, his bond must be slashed, and `challenger` must be able to claim it, 
+            // along with his bond for initiating the challenge
             await txlib.withdrawBonds(plasma, elliot, 0.2);
         });
 
@@ -336,8 +339,9 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
             assert.equal(await cards.balanceOf.call(elliot), 0);
             assert.equal(await cards.balanceOf.call(plasma.address), 3);
 
-            // // On the contrary, his bond must be slashed, and `challenger` must be able to claim it
-            await txlib.withdrawBonds(plasma, challenger, 0.1);
+            // On the contrary, his bond must be slashed, and `challenger` must be able to claim it, 
+            // along with his bond for initiating the challenge
+            await txlib.withdrawBonds(plasma, challenger, 0.2);
         });
 
         async function elliotInvalidHistoryExit(UTXO) {


### PR DESCRIPTION
Fixes #103:
> When challenging an invalid history (challengeBefore), a challenger has to submit a bond. When finalizing the exit and it is still in CHALLENGED state, the bond of the exitor is transferred to the challenger, but the combined bond is never freed? Shouldn't it be freed for posting the challenge?