### PR TITLE
Allow multiple challenges and split challenge period

### DIFF
--- a/loom_integration_test.sh
+++ b/loom_integration_test.sh
@@ -147,7 +147,8 @@ cd $REPO_ROOT/loom_test
 ./plasmacash_challenge_after_tester -hostile
 ./plasmacash_challenge_between_tester -hostile
 ./plasmacash_challenge_before_tester -hostile
-./plasmacash_respond_challenge_before_tester -hostile
+# Comment out until golang code is updated for responses
+# ./plasmacash_respond_challenge_before_tester -hostile
 
 stop_chains
 # Wait for Ganache & Loom to stop

--- a/loom_integration_test.sh
+++ b/loom_integration_test.sh
@@ -90,6 +90,11 @@ function download_dappchain {
     export LOOM_BIN=`pwd`/loom
 }
 
+if [[ "$IS_JENKINS_ENV" == true ]]; then
+    # Kill off any plugins that weren't killed off by older builds
+    pkill -f "hostileoperator.1.0.0" || true
+fi
+
 # BUILD_TAG is usually only set by Jenkins, so when running locally just hardcode some value
 if [[ -z "$BUILD_TAG" ]]; then
     BUILD_TAG=123

--- a/loom_integration_test.sh
+++ b/loom_integration_test.sh
@@ -6,7 +6,7 @@
 set -exo pipefail
 
 # Loom build to use for tests when running on Jenkins, this build will be automatically downloaded.
-BUILD_NUMBER=335
+BUILD_NUMBER=343
 
 # These can be toggled via the options below, only useful when running the script locally.
 LOOM_INIT_ONLY=false

--- a/loom_integration_test.sh
+++ b/loom_integration_test.sh
@@ -152,8 +152,7 @@ cd $REPO_ROOT/loom_test
 ./plasmacash_challenge_after_tester -hostile
 ./plasmacash_challenge_between_tester -hostile
 ./plasmacash_challenge_before_tester -hostile
-# Comment out until golang code is updated for responses
-# ./plasmacash_respond_challenge_before_tester -hostile
+./plasmacash_respond_challenge_before_tester -hostile
 
 stop_chains
 # Wait for Ganache & Loom to stop

--- a/loom_js_test/package.json
+++ b/loom_js_test/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "bn.js": "^4.11.8",
     "ethereumjs-util": "^5.2.0",
-    "loom-js": "1.15.0",
+    "loom-js": "1.16.0",
     "rlp": "^2.1.0",
     "web3": "^1.0.0-beta.34"
   },

--- a/loom_js_test/package.json
+++ b/loom_js_test/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "bn.js": "^4.11.8",
     "ethereumjs-util": "^5.2.0",
-    "loom-js": "1.16.0",
+    "loom-js": "1.16.1",
     "rlp": "^2.1.0",
     "web3": "^1.0.0-beta.34"
   },

--- a/loom_js_test/src/respond-challenge-before-demo.ts
+++ b/loom_js_test/src/respond-challenge-before-demo.ts
@@ -33,7 +33,7 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
 
   const startBlockNum = await web3.eth.getBlockNumber()
   // Trudy deposits a coin
-  await cards.depositToPlasmaAsync({ tokenId: 4, from: trudy.ethAddress })
+  await cards.depositToPlasmaAsync({ tokenId: 21, from: trudy.ethAddress })
 
   const depositEvents: any[] = await authority.plasmaCashContract.getPastEvents('Deposit', {
     fromBlock: startBlockNum
@@ -77,14 +77,13 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
 
   // Dan gets the transaction hash used for the above challenge
   // and responds to it
-
-  // TODO: Get info from the event
   const challengeEvents: any[] = await authority.plasmaCashContract.getPastEvents('ChallengedExit', {
     fromBlock: startBlockNum
   })
   const challenges = challengeEvents.map<IPlasmaChallenge>(event =>
     marshalChallengeEvent(event.returnValues)
   )
+  console.log('CHALLENGES FOUND', challenges);
 
   await dan.respondChallengeBeforeAsync({
     slot: deposit1Slot,

--- a/loom_js_test/src/respond-challenge-before-demo.ts
+++ b/loom_js_test/src/respond-challenge-before-demo.ts
@@ -83,8 +83,6 @@ export async function runRespondChallengeBeforeDemo(t: test.Test) {
   const challenges = challengeEvents.map<IPlasmaChallenge>(event =>
     marshalChallengeEvent(event.returnValues)
   )
-  console.log('CHALLENGES FOUND', challenges);
-
   await dan.respondChallengeBeforeAsync({
     slot: deposit1Slot,
     challengingTxHash: challenges[0].txHash,

--- a/loom_js_test/yarn.lock
+++ b/loom_js_test/yarn.lock
@@ -4425,9 +4425,9 @@ long@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
-loom-js@1.16.0:
-  version "1.16.0"
-  resolved "https://registry.yarnpkg.com/loom-js/-/loom-js-1.16.0.tgz#bb75c9a71e9daa3d93f58fcaffea7d85c29f217e"
+loom-js@1.16.1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/loom-js/-/loom-js-1.16.1.tgz#8da659def01a079ff866e942feede1523c0368a1"
   dependencies:
     axios "^0.18.0"
     bn.js "^4.11.8"

--- a/loom_js_test/yarn.lock
+++ b/loom_js_test/yarn.lock
@@ -4425,9 +4425,9 @@ long@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
-loom-js@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/loom-js/-/loom-js-1.15.0.tgz#14bf9990b2e2aba50668694b4e6d685c5f9285ef"
+loom-js@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/loom-js/-/loom-js-1.16.0.tgz#bb75c9a71e9daa3d93f58fcaffea7d85c29f217e"
   dependencies:
     axios "^0.18.0"
     bn.js "^4.11.8"

--- a/loom_test/src/client/client.go
+++ b/loom_test/src/client/client.go
@@ -196,7 +196,7 @@ func (c *Client) RespondChallengeBefore(slot uint64, respondingBlockNumber int64
 	}
 
 	txHash, err := c.RootChain.RespondChallengeBefore(slot,
-        challengingTxHash,
+		challengingTxHash,
 		respondingBlockNumber,
 		respondingTx,
 		proof,

--- a/loom_test/src/client/client.go
+++ b/loom_test/src/client/client.go
@@ -188,18 +188,19 @@ func (c *Client) ChallengeBefore(slot uint64, prevTxBlkNum int64, txBlkNum int64
 
 // RespondChallengeBefore - Respond to an exit with invalid history challenge by proving that
 // you were given the coin under question
-func (c *Client) RespondChallengeBefore(slot uint64, challengingBlockNumber int64) ([]byte, error) {
-	challengingTx, proof, err := c.getTxAndProof(challengingBlockNumber,
+func (c *Client) RespondChallengeBefore(slot uint64, respondingBlockNumber int64, challengingTxHash [32]byte) ([]byte, error) {
+	respondingTx, proof, err := c.getTxAndProof(respondingBlockNumber,
 		slot)
 	if err != nil {
 		return nil, err
 	}
 
 	txHash, err := c.RootChain.RespondChallengeBefore(slot,
-		challengingBlockNumber,
-		challengingTx,
+        challengingTxHash,
+		respondingBlockNumber,
+		respondingTx,
 		proof,
-		challengingTx.Sig())
+		respondingTx.Sig())
 	return txHash, err
 }
 

--- a/loom_test/src/client/root_chain_service.go
+++ b/loom_test/src/client/root_chain_service.go
@@ -203,7 +203,6 @@ func (d *RootChainService) ChallengedExitEventData(txHash common.Hash) (*plasma_
 	return &plasma_cash.ChallengedExitEventData{Slot: de.Slot, TxHash: de.TxHash}, err
 }
 
-
 func (d *RootChainService) DepositEventData(txHash common.Hash) (*plasma_cash.DepositEventData, error) {
 	receipt, err := conn.TransactionReceipt(context.TODO(), txHash)
 	if err != nil {

--- a/loom_test/src/cmd/respond_challenge_before_demo/main.go
+++ b/loom_test/src/cmd/respond_challenge_before_demo/main.go
@@ -72,12 +72,12 @@ func main() {
 	// TODO: Dan should start watching for challenges of depositSlot1
 
 	fmt.Println("Trudy attempts to challenge Dan's exit...")
-    challengeTxHash, err := trudy.ChallengeBefore(depositSlot1, 0, coin.DepositBlockNum)
+	challengeTxHash, err := trudy.ChallengeBefore(depositSlot1, 0, coin.DepositBlockNum)
 	exitIfError(err)
 
 	challengedExitEvent, err := trudy.RootChain.ChallengedExitEventData(common.BytesToHash(challengeTxHash))
 	exitIfError(err)
-    challengingTxHash := challengedExitEvent.TxHash
+	challengingTxHash := challengedExitEvent.TxHash
 
 	// TODO: Response should be automatic as long as the client is watching for challenges
 	fmt.Println("Dan responds to the invalid challenge...")

--- a/loom_test/src/cmd/respond_challenge_before_demo/main.go
+++ b/loom_test/src/cmd/respond_challenge_before_demo/main.go
@@ -72,12 +72,16 @@ func main() {
 	// TODO: Dan should start watching for challenges of depositSlot1
 
 	fmt.Println("Trudy attempts to challenge Dan's exit...")
-	_, err = trudy.ChallengeBefore(depositSlot1, 0, coin.DepositBlockNum)
+    challengeTxHash, err := trudy.ChallengeBefore(depositSlot1, 0, coin.DepositBlockNum)
 	exitIfError(err)
+
+	challengedExitEvent, err := trudy.RootChain.ChallengedExitEventData(common.BytesToHash(challengeTxHash))
+	exitIfError(err)
+    challengingTxHash := challengedExitEvent.TxHash
 
 	// TODO: Response should be automatic as long as the client is watching for challenges
 	fmt.Println("Dan responds to the invalid challenge...")
-	_, err = dan.RespondChallengeBefore(depositSlot1, trudyToDanBlockNum)
+	_, err = dan.RespondChallengeBefore(depositSlot1, trudyToDanBlockNum, challengingTxHash)
 	exitIfError(err)
 
 	// Jump forward in time by 8 days

--- a/plasma_cash/contract_binds/plasma_cash.py
+++ b/plasma_cash/contract_binds/plasma_cash.py
@@ -36,15 +36,17 @@ class PlasmaCash(Contract):
     def respond_challenge_before(
         self,
         slot,
-        challenging_block_number,
-        challenging_transaction,
+        challenging_tx_hash,
+        responding_block_number,
+        responding_transaction,
         proof,
         sig,
     ):
         args = [
             slot,
-            challenging_block_number,
-            challenging_transaction,
+            challenging_tx_hash,
+            responding_block_number,
+            responding_transaction,
             proof,
             sig,
         ]

--- a/plasma_cash/unit_test.py
+++ b/plasma_cash/unit_test.py
@@ -22,9 +22,10 @@ class TestSparseMerkleTree(object):
     def test_empty_SMT(self):
         emptyTree = SparseMerkleTree(64, {})
         assert len(emptyTree.leaves) == 0
-        assert (
-            emptyTree.root
-            == bytes(HexBytes('0x6f35419d1da1260bc0f33d52e8f6d73fc5d672c0dca13bb960b4ae1adec17937'))
+        assert emptyTree.root == bytes(
+            HexBytes(
+                '0x6f35419d1da1260bc0f33d52e8f6d73fc5d672c0dca13bb960b4ae1adec17937'
+            )
         )
 
     def test_all_leaves_with_val(self):
@@ -96,7 +97,9 @@ class TestSparseMerkleTree(object):
 
     def test_real_slot_proofs(self):
         slot = 14414645988802088183
-        txHash = HexBytes('0x510a183d5457e0d22951440a273f0d8e28e01d15f750d79fd1b27442299f7220')
+        txHash = HexBytes(
+            '0x510a183d5457e0d22951440a273f0d8e28e01d15f750d79fd1b27442299f7220'
+        )
         tree = SparseMerkleTree(64, {slot: txHash})
         proof = tree.create_merkle_proof(slot)
         inc = tree.verify(slot, proof)
@@ -104,11 +107,23 @@ class TestSparseMerkleTree(object):
 
     def test_real_tree_roots(self):
         slot = 14414645988802088183
-        txHash = HexBytes('0x4b114962ecf0d681fa416dc1a6f0255d52d701ab53433297e8962065c9d439bd')
+        txHash = HexBytes(
+            '0x4b114962ecf0d681fa416dc1a6f0255d52d701ab53433297e8962065c9d439bd'
+        )
         tree = SparseMerkleTree(64, {slot: txHash})
-        assert tree.root == bytes(HexBytes('0x0ed6599c03641e5a20d9688f892278dbb48bbcf8b1ff2c9a0e2b7423af831a83'))
+        assert tree.root == bytes(
+            HexBytes(
+                '0x0ed6599c03641e5a20d9688f892278dbb48bbcf8b1ff2c9a0e2b7423af831a83'
+            )
+        )
 
         slot = 14414645988802088183
-        txHash = HexBytes('0x510a183d5457e0d22951440a273f0d8e28e01d15f750d79fd1b27442299f7220')
+        txHash = HexBytes(
+            '0x510a183d5457e0d22951440a273f0d8e28e01d15f750d79fd1b27442299f7220'
+        )
         tree = SparseMerkleTree(64, {slot: txHash})
-        assert tree.root == bytes(HexBytes('0x8d0ae4c94eaad54df5489e5f9d62eeb4bf06ff774a00b925e8a52776256e910f'))
+        assert tree.root == bytes(
+            HexBytes(
+                '0x8d0ae4c94eaad54df5489e5f9d62eeb4bf06ff774a00b925e8a52776256e910f'
+            )
+        )

--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -472,8 +472,8 @@ contract RootChain is ERC721Receiver {
 
         checkResponse(slot, index, respondingBlockNumber, respondingTransaction, signature, proof);
 
-        // If the exit was actually challenged and responded, penalize the challenger
-        slashBond(challenges[slot][index].challenger, coins[slot].exit.owner);
+        // If the exit was actually challenged and responded, penalize the challenger and award the responder
+        slashBond(challenges[slot][index].challenger, msg.sender);
 
         // Put coin back to the exiting state
         coins[slot].state = State.EXITING;

--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -434,7 +434,7 @@ contract RootChain is ERC721Receiver {
             signature,
             blocks
         );
-        setChallenged(slot, txBytes.getOwner(), blocks[1]);
+        setChallenged(slot, txBytes.getOwner(), blocks[1], txBytes.getHash());
     }
 
     // If `challengeBefore` is successfully responded to, then set state to
@@ -524,7 +524,7 @@ contract RootChain is ERC721Receiver {
 
     /// @param slot The slot of the coin being challenged
     /// @param owner The user claimed to be the true ower of the coin
-    function setChallenged(uint64 slot, address owner, uint256 challengingBlockNumber) private {
+    function setChallenged(uint64 slot, address owner, uint256 challengingBlockNumber, bytes32 txHash) private {
         // Require that the challenge is in the first half of the challenge window
         require(block.timestamp <= coins[slot].exit.createdAt + CHALLENGE_WINDOW);
 

--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -373,6 +373,9 @@ contract RootChain is ERC721Receiver {
             freeBond(coin.owner);
 
             emit FinalizedExit(slot, coin.owner);
+        } else {
+            // Reset coin state since it was challenged
+            coin.state = State.DEPOSITED;
         }
 
         delete coins[slot].exit;
@@ -387,6 +390,8 @@ contract RootChain is ERC721Receiver {
                 slashBond(coins[slot].exit.owner, challenges[slot][i].challenger);
                 freeBond(challenges[slot][i].challenger);
 
+                // Challenge resolved, delete it
+                delete challenges[slot][i];
                 hasChallenges = true;
             }
         }

--- a/server/contracts/Core/RootChain.sol
+++ b/server/contracts/Core/RootChain.sol
@@ -447,14 +447,12 @@ contract RootChain is ERC721Receiver {
     function respondChallengeBefore(
         uint64 slot,
         uint256 challengingBlockNumber,
-        bytes challengingTransaction,
+        bytes32 challengingTxHash,
         bytes respondingTransaction,
         bytes proof,
         bytes signature)
         external
     {
-        bytes32 challengingTxHash = challengingTransaction.getHash();
-
         // Check that the transaction being challenged exists
         require(challenges[slot].contains(challengingTxHash), "Responding to non existing challenge");
 

--- a/server/contracts/Libraries/ChallengeLib.sol
+++ b/server/contracts/Libraries/ChallengeLib.sol
@@ -15,12 +15,12 @@ library ChallengeLib {
     }
 
     function contains(Challenge[] storage _array, bytes32 txHash) internal view returns (bool) {
-        int index = _indexOf(_array, txHash);
+        int index = indexOf(_array, txHash);
         return index != -1;
     }
 
     function remove(Challenge[] storage _array, bytes32 txHash) internal returns (bool) {
-        int index = _indexOf(_array, txHash);
+        int index = indexOf(_array, txHash);
         if (index == -1) {
             return false; // Tx not in challenge arraey
         }
@@ -34,7 +34,7 @@ library ChallengeLib {
         return true;
     }
 
-    function _indexOf(Challenge[] storage _array, bytes32 txHash) private view returns (int) {
+    function indexOf(Challenge[] storage _array, bytes32 txHash) internal view returns (int) {
         for (uint i = 0; i < _array.length; i++) {
             if (_array[i].txHash == txHash) {
                 return int(i);

--- a/server/contracts/Libraries/ChallengeLib.sol
+++ b/server/contracts/Libraries/ChallengeLib.sol
@@ -1,0 +1,45 @@
+pragma solidity ^0.4.24;
+
+/**
+* @title ChallengeLib
+*
+* ChallengeLib is a helper library for constructing challenges
+*/
+
+library ChallengeLib {
+    struct Challenge {
+        address owner;
+        address challenger;
+        bytes32 txHash;
+        uint256 challengingBlockNumber;
+    }
+
+    function contains(Challenge[] storage _array, bytes32 txHash) internal view returns (bool) {
+        int index = _indexOf(_array, txHash);
+        return index != -1;
+    }
+
+    function remove(Challenge[] storage _array, bytes32 txHash) internal returns (bool) {
+        int index = _indexOf(_array, txHash);
+        if (index == -1) {
+            return false; // Tx not in challenge arraey
+        }
+        // Replace element with last element
+        Challenge memory lastChallenge = _array[_array.length - 1];
+        _array[uint(index)] = lastChallenge;
+
+        // Reduce array length
+        delete _array[_array.length - 1];
+        _array.length -= 1;
+        return true;
+    }
+
+    function _indexOf(Challenge[] storage _array, bytes32 txHash) private view returns (int) {
+        for (uint i = 0; i < _array.length; i++) {
+            if (_array[i].txHash == txHash) {
+                return int(i);
+            }
+        }
+        return -1;
+    }
+}

--- a/server/contracts/Libraries/Transaction/Transaction.sol
+++ b/server/contracts/Libraries/Transaction/Transaction.sol
@@ -32,6 +32,18 @@ library Transaction {
         return transaction;
     }
 
+    function getHash(bytes memory txBytes) internal pure returns (bytes32 hash) {
+        RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(4);
+        uint64 slot = uint64(rlpTx[0].toUint());
+        uint256 prevBlock = uint256(rlpTx[1].toUint());
+
+        if (prevBlock == 0) { // deposit transaction
+            hash = keccak256(abi.encodePacked(slot));
+        } else {
+            hash = keccak256(txBytes);
+        }
+    }
+
     function getOwner(bytes memory txBytes) internal pure returns (address owner) {
         RLP.RLPItem[] memory rlpTx = txBytes.toRLPItem().toList(4);
         owner = rlpTx[3].toAddress();

--- a/server/migrations/2_deploy_contract.js
+++ b/server/migrations/2_deploy_contract.js
@@ -13,7 +13,7 @@ module.exports = async function(deployer, network, accounts) {
         console.log(`RootChain deployed at address: ${root.address}`);
 
         await deployer.deploy(CryptoCards, root.address);
-        const cards = await RootChain.deployed();
+        const cards = await CryptoCards.deployed();
         console.log(`CryptoCards deployed at address: ${cards.address}`);
 
         await vmc.toggleToken(cards.address);

--- a/server/migrations/2_deploy_contract.js
+++ b/server/migrations/2_deploy_contract.js
@@ -3,30 +3,20 @@ const RootChain = artifacts.require("RootChain");
 const ValidatorManagerContract = artifacts.require("ValidatorManagerContract");
 
 module.exports = async function(deployer, network, accounts) {
-    // return; // for testing
-    let aCryptoCardsInstance;
-    let aRootChainInstance;
-    let aValidatorManagerContractInstance;
 
-    return deployer.deploy(ValidatorManagerContract)
-        .then(() => ValidatorManagerContract.deployed())
-        .then(instance => {
-            aValidatorManagerContractInstance = instance;
-            console.log('ValidatorManagerContract deployed at address: ' + instance.address);
-            return deployer.deploy(RootChain, instance.address);
-        })
-        .then(() => RootChain.deployed())
-        .then(instance => {
-            aRootChainInstance = instance;
-            console.log('RootChain deployed at address: ' + instance.address);
-            return deployer.deploy(CryptoCards, instance.address);
-        })
-    .then(() => CryptoCards.deployed())
-        .then((instance) => {
-            aCryptoCardsInstance = instance;
-            console.log('CryptoCards deployed at address: ' + instance.address);
+    deployer.deploy(ValidatorManagerContract).then(async () => {
+        const vmc = await ValidatorManagerContract.deployed();
+        console.log(`ValidatorManagerContract deployed at address: ${vmc.address}`);
 
-            aValidatorManagerContractInstance.toggleToken(instance.address);
-        });
+        await deployer.deploy(RootChain, vmc.address);
+        const root = await RootChain.deployed();
+        console.log(`RootChain deployed at address: ${root.address}`);
+
+        await deployer.deploy(CryptoCards, root.address);
+        const cards = await RootChain.deployed();
+        console.log(`CryptoCards deployed at address: ${cards.address}`);
+
+        await vmc.toggleToken(cards.address);
+    });
 };
 

--- a/server/test/testChallengeBefore.js
+++ b/server/test/testChallengeBefore.js
@@ -285,11 +285,6 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
             // Bob is able to get both her bond and Elliot's invalid exit bond
             await txlib.withdrawBonds(plasma, charlie, 0.2);
         });
-
-        it('Invalid time for a challenge', function() {
-            console.log('Challenges after RESPONSE_PERIOD are reverted. Prevents griefing vector');
-        })
-
     });
 
     describe('With Responses', function() {
@@ -588,20 +583,144 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
                 // Bond withdrawals
                 await plasma.withdrawBonds({from: elliot});
                 await plasma.withdrawBonds({from: alice});
-
                 let withdrewBonds = plasma.WithdrewBonds({}, {fromBlock: 0, toBlock: 'latest'});
-                let e = await txlib.Promisify(cb => withdrewBonds.get(cb));
+                let eventLog = await txlib.Promisify(cb => withdrewBonds.get(cb));
 
                 // Elliot is able to get the challenger's bond
                 // (nothing gained since they are all colluding)
-                let elliot_bond = e[0].args;
+                let elliot_bond = eventLog[0].args;
                 assert.equal(elliot_bond.from, elliot);
                 assert.equal(elliot_bond.amount, web3.toWei(0.1, 'ether'));
 
                 // Alice gets her own bond back and the exitor's bond
-                let alice_bond = e[1].args;
+                let alice_bond = eventLog[1].args;
                 assert.equal(alice_bond.from, alice);
                 assert.equal(alice_bond.amount, web3.toWei(0.2, 'ether'));
+            });
+
+            it("Invalid exit - Not challenged in time", async function() {
+                let UTXO = {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()};
+
+                // Bob/Operator forges a transaction and gives the coin all the way to Elliot
+                // Elliot exits, Bob challenges,
+                // The authority submits a block, but there is no transaction from Alice to Bob
+                let tree_bob = await txlib.submitTransactions(authority, plasma);
+
+                // Nevertheless, Bob pretends he received the coin, and by
+                // colluding with the chain operator he is able to include his
+                // invalid transaction in a block.
+                let bob_to_charlie = txlib.createUTXO(UTXO.slot, 1000, bob, charlie);
+                let txs = [bob_to_charlie.leaf]
+                let tree_charlie = await txlib.submitTransactions(authority, plasma, txs);
+
+                // Charlie having received the coin, gives it to Dylan.
+                let charlie_to_dylan = txlib.createUTXO(UTXO.slot, 2000, charlie, dylan);
+                txs = [charlie_to_dylan.leaf]
+                let tree_dylan = await txlib.submitTransactions(authority, plasma, txs);
+
+                // Dylan having received the coin, gives it to Elliot.
+                let dylan_to_elliot = txlib.createUTXO(UTXO.slot, 3000, dylan, elliot);
+                txs = [dylan_to_elliot.leaf]
+                let tree_elliot = await txlib.submitTransactions(authority, plasma, txs);
+                //
+                // Dylan having received the coin, gives it to Elliot.
+                let elliot_to_fred = txlib.createUTXO(UTXO.slot, 4000, elliot, fred);
+                txs = [elliot_to_fred.leaf]
+                let tree_fred = await txlib.submitTransactions(authority, plasma, txs);
+
+                // Elliot normally should be always checking the coin's history and
+                // not accepting the payment if it's invalid like in this case, but
+                // it is considered that they are all colluding together to steal
+                // Bob's coin.  Elliot has all the info required to submit
+                // an exit, even if one of the transactions in the coin's history
+                // were invalid.
+                let sig = elliot_to_fred.sig;
+                let prev_tx_proof = tree_elliot.createMerkleProof(UTXO.slot)
+                let exiting_tx_proof = tree_fred.createMerkleProof(UTXO.slot)
+                let prev_tx = dylan_to_elliot.tx;
+                let exiting_tx = elliot_to_fred.tx;
+
+                // Fred submits the exit which is valid as far as the chain is concerned
+                await plasma.startExit(
+                    UTXO.slot,
+                    prev_tx, exiting_tx,
+                    prev_tx_proof, exiting_tx_proof,
+                    sig,
+                    [4000, 5000],
+                    {'from': fred, 'value': web3.toWei(0.1, 'ether')}
+                );
+                t0 = (await web3.eth.getBlock('latest')).timestamp;
+
+                // Dylan challenges the exit
+                sig = charlie_to_dylan.sig;
+                let tx_proof = tree_dylan.createMerkleProof(UTXO.slot)
+                prev_tx_proof = tree_charlie.createMerkleProof(UTXO.slot)
+                prev_tx = bob_to_charlie.tx;
+                let tx = charlie_to_dylan.tx;
+                await plasma.challengeBefore(
+                    UTXO.slot,
+                    prev_tx , tx,
+                    prev_tx_proof, tx_proof,
+                    sig,
+                    [2000, 3000],
+                    {'from': dylan, 'value': web3.toWei(0.1, 'ether')}
+                );
+
+                // No more challenges can be issued
+                await increaseTimeTo(t0 + RESPONSE_PERIOD + e);
+                // Alice can no longer challenge the exit! :(
+                let alice_to_alice = txlib.createUTXO(UTXO.slot, 0, alice, alice);
+                assertRevert(plasma.challengeBefore(
+                    UTXO.slot,
+                    '0x0' , alice_to_alice.tx,
+                    '0x0', '0x0',
+                    alice_to_alice.sig,
+                    [0, UTXO.block],
+                    {'from': alice, 'value': web3.toWei(0.1, 'ether')}
+                ));
+
+                // Elliot responds to the challenge (this time it will complete the robbery)
+                let challengingTxHash = charlie_to_dylan.leaf.hash;
+                let responseTx = dylan_to_elliot.tx;
+                sig = dylan_to_elliot.sig;
+                let responseProof = tree_elliot.createMerkleProof(UTXO.slot);
+                await plasma.respondChallengeBefore(
+                    UTXO.slot, challengingTxHash, 4000, responseTx, responseProof, sig,
+                    {'from': elliot}
+                );
+
+                await increaseTimeTo(t0 + MATURITY_PERIOD + e);
+                await plasma.finalizeExits({from: random_guy2});
+
+                // Fred withdraws the coin.
+                await plasma.withdraw(UTXO.slot, {from : fred});
+
+                assert.equal(await cards.balanceOf.call(alice), 2);
+                assert.equal(await cards.balanceOf.call(bob), 0);
+                assert.equal(await cards.balanceOf.call(charlie), 0);
+                assert.equal(await cards.balanceOf.call(dylan), 0);
+                assert.equal(await cards.balanceOf.call(elliot), 0);
+                assert.equal(await cards.balanceOf.call(fred), 1);
+                assert.equal(await cards.balanceOf.call(plasma.address), 2);
+
+
+                // Bond withdrawals
+                await plasma.withdrawBonds({from: elliot});
+                await plasma.withdrawBonds({from: fred});
+
+                let withdrewBonds = plasma.WithdrewBonds({}, {fromBlock: 0, toBlock: 'latest'});
+                let eventLog = await txlib.Promisify(cb => withdrewBonds.get(cb));
+
+                // Elliot is able to get the challenger's bond
+                // (nothing gained since they are all colluding)
+                let elliot_bond = eventLog[0].args;
+                assert.equal(elliot_bond.from, elliot);
+                assert.equal(elliot_bond.amount, web3.toWei(0.1, 'ether'));
+
+                // Alice gets her own bond back and the exitor's bond
+                let fred_bond = eventLog[1].args;
+                assert.equal(fred_bond.from, fred);
+                assert.equal(fred_bond.amount, web3.toWei(0.1, 'ether'));
             });
 
         });

--- a/server/test/testChallengeBefore.js
+++ b/server/test/testChallengeBefore.js
@@ -8,8 +8,9 @@ const txlib = require('./UTXO.js')
 
 contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async function(accounts) {
 
-    const t1 = 3600 * 24 * 3; // 3 days later
-    const t2 = 3600 * 24 * 5; // 5 days later
+    const RESPONSE_PERIOD = 3600 * 24 * 3.5; // 3.5 days later
+    const MATURITY_PERIOD = 3600 * 24 * 7; // 3.5 days later
+    const e = 3600;
 
     // Alice registers and has 5 coins, and she deposits 3 of them.
     const ALICE_INITIAL_COINS = 5;
@@ -22,7 +23,7 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
     let events;
     let t0;
 
-    let [authority, alice, bob, charlie, dylan, elliot, random_guy, random_guy2, challenger] = accounts;
+    let [authority, alice, bob, charlie, dylan, elliot, fred, random_guy, random_guy2, challenger] = accounts;
 
 
     beforeEach(async function() {
@@ -56,55 +57,244 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
 
     });
 
-    describe('Invalid Exit of UTXO 2', function() {
+    // TODO Timing attacks
 
-        it("Elliot tries to exit a coin that has invalid history. Elliot's exit gets challenged with challengeBefore w/o response as there is no valid transaction to respond with", async function() {
-            let UTXO = {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()};
-            let ret = await elliotInvalidHistoryExit(UTXO);
-            let alice_to_bob = ret.data;
-            let tree_bob = ret.tree;
+    describe('Without Responses', function() {
 
-            // Concatenate the 2 signatures
-            let sig = alice_to_bob.sig;
-            let tx_proof = tree_bob.createMerkleProof(UTXO.slot)
+        describe("Operator includes invalid transaction in a block", async function() {
 
-            let prev_tx = txlib.createUTXO(UTXO.slot, 0, alice, alice).tx;
-            let tx = alice_to_bob.tx;
+            it("Directly after deposit", async function() {
+                let UTXO = {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()};
 
-            // Challenge before is essentially a challenge where the challenger
-            // submits the proof required to exit a coin, claiming that this is
-            // the last valid state of a coin. Due to bonds the challenger will
-            // only do this when he actually knows that there was an invalid
-            // spend. If the challenger is a rational player, there should be
-            // no case where respondChallengeBefore should succeed.
-            await plasma.challengeBefore(
-                UTXO.slot,
-                prev_tx , tx, // rlp encoded
-                '0x0', tx_proof, // proofs from the tree
-                sig, // concatenated signatures
-                [UTXO.block, 1000],
-                {'from': challenger, 'value': web3.toWei(0.1, 'ether')}
-            );
+                // The authority submits a block, but there is no transaction from Alice to Bob
+                let tree_bob = await txlib.submitTransactions(authority, plasma);
 
-            t0 = (await web3.eth.getBlock('latest')).timestamp;
-            await increaseTimeTo( t0 + t1 + t2);
-            await plasma.finalizeExits({from: random_guy2});
+                // Nevertheless, Bob pretends he received the coin, and by
+                // colluding with the chain operator he is able to include his
+                // invalid transaction in a block.
+                let bob_to_charlie = txlib.createUTXO(UTXO.slot, 1000, bob, charlie);
+                let txs = [bob_to_charlie.leaf]
+                let tree_charlie = await txlib.submitTransactions(authority, plasma, txs);
 
-            // Charlie shouldn't be able to withdraw the coin.
-            assertRevert(plasma.withdraw(UTXO.slot, {from : elliot}));
+                // Charlie having received the coin, gives it to Dylan.
+                let charlie_to_dylan = txlib.createUTXO(UTXO.slot, 2000, charlie, dylan);
+                txs = [charlie_to_dylan.leaf]
+                let tree_dylan = await txlib.submitTransactions(authority, plasma, txs);
 
-            assert.equal(await cards.balanceOf.call(alice), 2);
-            assert.equal(await cards.balanceOf.call(bob), 0);
-            assert.equal(await cards.balanceOf.call(charlie), 0);
-            assert.equal(await cards.balanceOf.call(dylan), 0);
-            assert.equal(await cards.balanceOf.call(elliot), 0);
-            assert.equal(await cards.balanceOf.call(plasma.address), 3);
+                // Dylan normally should be always checking the coin's history and
+                // not accepting the payment if it's invalid like in this case, but
+                // it is considered that they are all colluding together to steal
+                // Alice's coin.  Dylan has all the info required to submit
+                // an exit, even if one of the transactions in the coin's history
+                // were invalid.
+                let sig = charlie_to_dylan.sig;
+                let prev_tx_proof = tree_charlie.createMerkleProof(UTXO.slot)
+                let exiting_tx_proof = tree_dylan.createMerkleProof(UTXO.slot)
+                let prev_tx = bob_to_charlie.tx;
+                let exiting_tx = charlie_to_dylan.tx;
 
-            // On the contrary, his bond must be slashed, and `challenger` must be able to claim it
-            await txlib.withdrawBonds(plasma, challenger, 0.1);
+                // Dylan submits the invalid exit and waits.
+                await plasma.startExit(
+                    UTXO.slot,
+                    prev_tx, exiting_tx,
+                    prev_tx_proof, exiting_tx_proof,
+                    sig,
+                    [2000, 3000],
+                    {'from': dylan, 'value': web3.toWei(0.1, 'ether')}
+                );
+                t0 = (await web3.eth.getBlock('latest')).timestamp;
+
+                // Alice has seen the collusion scheme and submits a challenge
+                let alice_to_alice = txlib.createUTXO(UTXO.slot, 0, alice, alice);
+                await plasma.challengeBefore(
+                    UTXO.slot,
+                    '0x0' , alice_to_alice.tx, 
+                    '0x0', '0x0', 
+                    alice_to_alice.sig,
+                    [0, UTXO.block],
+                    {'from': alice, 'value': web3.toWei(0.1, 'ether')}
+                );
+
+                // Go a litle after the maturity period
+                await increaseTimeTo(t0 + MATURITY_PERIOD + e);
+                await plasma.finalizeExits({from: random_guy2});
+
+                // Dylan shouldn't be able to withdraw the coin.
+                assertRevert(plasma.withdraw(UTXO.slot, {from : dylan}));
+
+                assert.equal(await cards.balanceOf.call(alice), 2);
+                assert.equal(await cards.balanceOf.call(bob), 0);
+                assert.equal(await cards.balanceOf.call(charlie), 0);
+                assert.equal(await cards.balanceOf.call(dylan), 0);
+                assert.equal(await cards.balanceOf.call(elliot), 0);
+                assert.equal(await cards.balanceOf.call(plasma.address), 3);
+
+                // Alice is able to get both her bond and Dylan's invalid exit bond
+                await txlib.withdrawBonds(plasma, alice, 0.2);
+            });
+
+            it("After 1 transfer", async function() {
+                let UTXO = {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()};
+
+                // Alice gives her coin legitimately to Bob
+                let alice_to_bob = txlib.createUTXO(UTXO.slot, UTXO.block, alice, bob);
+                let txs = [alice_to_bob.leaf]
+                let tree_bob = await txlib.submitTransactions(authority, plasma, txs);
+
+                // The authority submits a block, but there is no transaction from Bob to Charlie
+                let tree_charlie = await txlib.submitTransactions(authority, plasma);
+
+                // Nevertheless, Charlie pretends he received the coin, and by
+                // colluding with the chain operator he is able to include his
+                // invalid transaction in a block.
+                let charlie_to_dylan = txlib.createUTXO(UTXO.slot, 2000, charlie, dylan);
+                txs = [charlie_to_dylan.leaf]
+                let tree_dylan = await txlib.submitTransactions(authority, plasma, txs);
+
+                // Dylan having received the coin, gives it to Elliot.
+                let dylan_to_elliot = txlib.createUTXO(UTXO.slot, 3000, dylan, elliot);
+                txs = [dylan_to_elliot.leaf]
+                let tree_elliot = await txlib.submitTransactions(authority, plasma, txs);
+
+                // Elliot normally should be always checking the coin's history and
+                // not accepting the payment if it's invalid like in this case, but
+                // it is considered that they are all colluding together to steal
+                // Bob's coin.  Elliot has all the info required to submit
+                // an exit, even if one of the transactions in the coin's history
+                // were invalid.
+                let sig = dylan_to_elliot.sig;
+                let prev_tx_proof = tree_dylan.createMerkleProof(UTXO.slot)
+                let exiting_tx_proof = tree_elliot.createMerkleProof(UTXO.slot)
+                let prev_tx = charlie_to_dylan.tx;
+                let exiting_tx = dylan_to_elliot.tx;
+
+                // Elliot submits the invalid exit and waits
+                await plasma.startExit(
+                    UTXO.slot,
+                    prev_tx, exiting_tx,
+                    prev_tx_proof, exiting_tx_proof,
+                    sig,
+                    [3000, 4000],
+                    {'from': elliot, 'value': web3.toWei(0.1, 'ether')}
+                );
+                t0 = (await web3.eth.getBlock('latest')).timestamp;
+
+                // Bob has seen the collusion scheme and challenges
+                sig = alice_to_bob.sig;
+                let tx_proof = tree_bob.createMerkleProof(UTXO.slot)
+                prev_tx = txlib.createUTXO(UTXO.slot, 0, alice, alice).tx;
+                let tx = alice_to_bob.tx;
+                await plasma.challengeBefore(
+                    UTXO.slot,
+                    prev_tx , tx,
+                    '0x0', tx_proof,
+                    sig,
+                    [UTXO.block, 1000],
+                    {'from': bob, 'value': web3.toWei(0.1, 'ether')}
+                );
+                await increaseTimeTo(t0 + MATURITY_PERIOD + e);
+                await plasma.finalizeExits({from: random_guy2});
+
+                // Elliot shouldn't be able to withdraw the coin.
+                assertRevert(plasma.withdraw(UTXO.slot, {from : elliot}));
+
+                assert.equal(await cards.balanceOf.call(alice), 2);
+                assert.equal(await cards.balanceOf.call(bob), 0);
+                assert.equal(await cards.balanceOf.call(charlie), 0);
+                assert.equal(await cards.balanceOf.call(dylan), 0);
+                assert.equal(await cards.balanceOf.call(elliot), 0);
+                assert.equal(await cards.balanceOf.call(plasma.address), 3);
+
+                // Bob is able to get both her bond and Elliot's invalid exit bond
+                await txlib.withdrawBonds(plasma, bob, 0.2);
+            });
+
+            it("After 2 transfers", async function() {
+                let UTXO = {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()};
+
+                // Alice gives her coin legitimately to Bob
+                let alice_to_bob = txlib.createUTXO(UTXO.slot, UTXO.block, alice, bob);
+                let txs = [alice_to_bob.leaf]
+                let tree_bob = await txlib.submitTransactions(authority, plasma, txs);
+
+                // Bob gives his coin legitimately to Charlie
+                let bob_to_charlie = txlib.createUTXO(UTXO.slot, UTXO.block, bob, charlie);
+                txs = [bob_to_charlie.leaf]
+                let tree_charlie = await txlib.submitTransactions(authority, plasma, txs);
+
+                // The authority submits a block, but there is no transaction from Charlie to Dylan
+                let tree_dylan = await txlib.submitTransactions(authority, plasma);
+
+                // Nevertheless, Dylan pretends he received the coin, and by
+                // colluding with the chain operator he is able to include his
+                // invalid transaction in a block.
+                let dylan_to_elliot = txlib.createUTXO(UTXO.slot, 4000, dylan, elliot);
+                txs = [dylan_to_elliot.leaf]
+                let tree_elliot = await txlib.submitTransactions(authority, plasma, txs);
+
+                // Elliot having received the coin, gives it to Fred.
+                let elliot_to_fred = txlib.createUTXO(UTXO.slot, 5000, elliot, fred);
+                txs = [elliot_to_fred.leaf]
+                let tree_fred = await txlib.submitTransactions(authority, plasma, txs);
+
+                // Fred normally should be always checking the coin's history and
+                // not accepting the payment if it's invalid like in this case, but
+                // it is considered that they are all colluding together to steal
+                // Bob's coin. Fred has all the info required to submit
+                // an exit, even if one of the transactions in the coin's history
+                // were invalid.
+                let sig = elliot_to_fred.sig;
+                let prev_tx_proof = tree_elliot.createMerkleProof(UTXO.slot)
+                let exiting_tx_proof = tree_fred.createMerkleProof(UTXO.slot)
+                let prev_tx = dylan_to_elliot.tx;
+                let exiting_tx = elliot_to_fred.tx;
+
+                // Fred submits the invalid exit and waits
+                await plasma.startExit(
+                    UTXO.slot,
+                    prev_tx, exiting_tx,
+                    prev_tx_proof, exiting_tx_proof,
+                    sig,
+                    [4000, 5000],
+                    {'from': fred, 'value': web3.toWei(0.1, 'ether')}
+                );
+                t0 = (await web3.eth.getBlock('latest')).timestamp;
+
+                // Charlie has seen the collusion scheme and challenges
+                sig = bob_to_charlie.sig;
+                prev_tx_proof = tree_bob.createMerkleProof(UTXO.slot)
+                let tx_proof = tree_charlie.createMerkleProof(UTXO.slot)
+                prev_tx = alice_to_bob.tx;
+                let challenging_tx = bob_to_charlie.tx;
+                await plasma.challengeBefore(
+                    UTXO.slot,
+                    prev_tx , challenging_tx,
+                    prev_tx_proof, tx_proof,
+                    sig,
+                    [1000, 2000],
+                    {'from': charlie, 'value': web3.toWei(0.1, 'ether')}
+                );
+                await increaseTimeTo(t0 + MATURITY_PERIOD + e);
+                await plasma.finalizeExits({from: random_guy2});
+
+                // Fred shouldn't be able to withdraw the coin.
+                assertRevert(plasma.withdraw(UTXO.slot, {from : fred}));
+
+                assert.equal(await cards.balanceOf.call(alice), 2);
+                assert.equal(await cards.balanceOf.call(bob), 0);
+                assert.equal(await cards.balanceOf.call(charlie), 0);
+                assert.equal(await cards.balanceOf.call(dylan), 0);
+                assert.equal(await cards.balanceOf.call(elliot), 0);
+                assert.equal(await cards.balanceOf.call(plasma.address), 3);
+
+                // Bob is able to get both her bond and Elliot's invalid exit bond
+                await txlib.withdrawBonds(plasma, charlie, 0.2);
+            });
         });
+    });
 
-        it("Alice gives coin to Bob who gives it back to Alice. After some time, an invalid spend of that coin happens. Alice challenges but challenger tries an invalid response", async function() {
+    describe('With Responses', function() {
+        it("Attempt to make an invalid response fails", async function() {
             let UTXO = {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()};
 
             // alice gives coin to bob
@@ -139,14 +329,11 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
             // an exit, even if one of the transactions in the coin's history
             // were invalid.
             let sig = dylan_to_elliot.sig;
-
             let prev_tx_proof = tree_dylan.createMerkleProof(UTXO.slot)
             let exiting_tx_proof = tree_elliot.createMerkleProof(UTXO.slot)
-
             let prev_tx = charlie_to_dylan.tx;
             let exiting_tx = dylan_to_elliot.tx;
-
-            plasma.startExit(
+            await plasma.startExit(
                 UTXO.slot,
                 prev_tx, exiting_tx,
                 prev_tx_proof, exiting_tx_proof,
@@ -154,180 +341,41 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
                 [4000, 5000],
                 {'from': elliot, 'value': web3.toWei(0.1, 'ether')}
             );
+            t0 = (await web3.eth.getBlock('latest')).timestamp;
 
-            // Concatenate the 2 signatures
             prev_tx = alice_to_bob.tx
             prev_tx_proof = tree_bob.createMerkleProof(UTXO.slot)
-
             exiting_tx_proof = tree_alice.createMerkleProof(UTXO.slot)
             exiting_tx = bob_to_alice.tx;
-
             sig = bob_to_alice.sig;
-
-            // Challenge before is essentially a challenge where the challenger
-            // submits the proof required to exit a coin, claiming that this is
-            // the last valid state of a coin. Due to bonds the challenger will
-            // only do this when he actually knows that there was an invalid
-            // spend. If the challenger is a rational player, there should be
-            // no case where respondChallengeBefore should succeed.
             await plasma.challengeBefore(
                 UTXO.slot,
-                prev_tx , exiting_tx, // rlp encoded
-                prev_tx_proof, exiting_tx_proof, // proofs from the tree
-                sig, // concatenated signatures
+                prev_tx , exiting_tx,
+                prev_tx_proof, exiting_tx_proof,
+                sig,
                 [1000, 2000],
-                {'from': challenger, 'value': web3.toWei(0.1, 'ether')}
+                {'from': alice, 'value': web3.toWei(0.1, 'ether')}
             );
+            
+            // Fast forward to the second window where responses are allowed
+            // await increaseTimeTo(t0 + RESPONSE_PERIOD + e);
 
-            let challengingTxHash = alice_to_bob.leaf.hash;
+            // Elliot tries to make an invalid response by providing
+            // the initial transfer from Alice to Bob. A valid response
+            // would involve a later spend
             let responseTx = alice_to_bob.tx;
             sig = alice_to_bob.sig;
             let responseProof = tree_bob.createMerkleProof(UTXO.slot);
+
+            // Get the tx hash of the challenge we are responding to
+            let challengingTxHash = alice_to_bob.leaf.hash;
 
             assertRevert(plasma.respondChallengeBefore(
                 UTXO.slot, 1000, challengingTxHash, responseTx, responseProof, sig,
                 {'from': elliot}
             ));
 
-        });
-
-        it("Elliot makes a valid exit which gets challenged, however he responds with `respondChallengeBefore`", async function() {
-            let UTXO = {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()};
-            let ret = await elliotValidHistoryExit(UTXO);
-            let alice_to_bob = ret.bob.data;
-            let tree_bob = ret.bob.tree;
-            let bob_to_charlie = ret.charlie.data;
-            let tree_charlie = ret.charlie.tree;
-
-            t0 = (await web3.eth.getBlock('latest')).timestamp;
-
-            // Concatenate the 2 signatures
-            let sig = alice_to_bob.sig;
-            let proof = tree_bob.createMerkleProof(UTXO.slot)
-
-            let prev_tx = txlib.createUTXO(UTXO.slot, 0, alice, alice).tx;
-            let tx = alice_to_bob.tx;
-
-            // Challenge before is essentially a challenge where the challenger
-            // submits the proof required to exit a coin, claiming that this is
-            // the last valid state of a coin. Due to bonds the challenger will
-            // only do this when he actually knows that there was an invalid
-            // spend. If the challenger is a rational player, there should be
-            // no case where respondChallengeBefore should succeed.
-            await plasma.challengeBefore(
-                UTXO.slot,
-                prev_tx , tx, // rlp encoded
-                '0x0', proof, // proofs from the tree
-                sig, // concatenated signatures
-                [3, 1000],
-                {'from': challenger, 'value': web3.toWei(0.1, 'ether')}
-            );
-
-            let challengingTxHash = alice_to_bob.leaf.hash;
-            let responseTx = bob_to_charlie.tx;
-            sig = bob_to_charlie.sig;
-            let responseProof = tree_charlie.createMerkleProof(UTXO.slot);
-
-            await plasma.respondChallengeBefore(
-                UTXO.slot, 2000, challengingTxHash, responseTx, responseProof, sig,
-                {'from': elliot}
-            );
-
-
-            await increaseTimeTo(t0 + t1 + t2);
-            await plasma.finalizeExits({from: random_guy2});
-            await plasma.withdraw(UTXO.slot, {from : elliot});
-
-            assert.equal((await cards.balanceOf.call(alice)).toNumber(), 2);
-            assert.equal((await cards.balanceOf.call(bob)).toNumber(), 0);
-            assert.equal((await cards.balanceOf.call(charlie)).toNumber(), 0);
-            assert.equal((await cards.balanceOf.call(dylan)).toNumber(), 0);
-            assert.equal((await cards.balanceOf.call(elliot)).toNumber(), 1);
-            assert.equal((await cards.balanceOf.call(plasma.address)).toNumber(), 2);
-
-            await txlib.withdrawBonds(plasma, elliot, 0.2);
-        });
-
-        it("Elliot tries to exit a coin that has invalid history. Elliot's exit gets challenged with challengeBefore. Elliot tries to provide an invalid response and fails", async function() {
-            let UTXO = {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()};
-
-            let alice_to_bob = txlib.createUTXO(UTXO.slot, UTXO.block, alice, bob);
-            let txs = [alice_to_bob.leaf]
-            let tree_1000 = await txlib.submitTransactions(authority, plasma, txs);
-
-            // Charlie creates a false transaction to himself and colludes with
-            // the operator to include it in the plasma chain
-            let bob_to_charlie = txlib.createUTXO(UTXO.slot, UTXO.block, charlie, charlie);
-            txs = [bob_to_charlie.leaf]
-            let tree_2000 = await txlib.submitTransactions(authority, plasma, txs);
-
-            // Charlie starts moving his coin around (Dylan/Elliot are Charlie's friends)
-            let charlie_to_dylan = txlib.createUTXO(UTXO.slot, 2000, charlie, dylan);
-            txs = [charlie_to_dylan.leaf]
-            let tree_3000 = await txlib.submitTransactions(authority, plasma, txs);
-            let dylan_to_elliot = txlib.createUTXO(UTXO.slot, 3000, dylan, elliot);
-            txs = [dylan_to_elliot.leaf]
-            let tree_4000 = await txlib.submitTransactions(authority, plasma, txs);
-
-            // Elliot normally should be always checking the coin's history and
-            // not accepting the payment if it's invalid like in this case, but
-            // it is considered that they are all colluding together to steal
-            // Bob's coin.  Elliot actually has all the info required to submit
-            // an exit, even if one of the transactions in the coin's history
-            // were invalid.
-            let sig = dylan_to_elliot.sig;
-
-            let prev_tx_proof = tree_3000.createMerkleProof(UTXO.slot)
-            let exiting_tx_proof = tree_4000.createMerkleProof(UTXO.slot)
-
-            let prev_tx = charlie_to_dylan.tx;
-            let exiting_tx = dylan_to_elliot.tx;
-
-            plasma.startExit(
-                UTXO.slot,
-                prev_tx, exiting_tx,
-                prev_tx_proof, exiting_tx_proof,
-                sig,
-                [3000, 4000],
-                {'from': elliot, 'value': web3.toWei(0.1, 'ether')}
-            );
-
-            // Challenger sees the invalid exit and proceeds to `challengeBefore`
-            // If the challenger is honest,
-            // then there is no valid response to the challenge
-            sig = alice_to_bob.sig;
-            let tx_proof = tree_1000.createMerkleProof(UTXO.slot)
-            prev_tx = txlib.createUTXO(UTXO.slot, 0, alice, alice).tx;
-            let tx = alice_to_bob.tx;
-
-            await plasma.challengeBefore(
-                UTXO.slot,
-                prev_tx , tx, // rlp encoded
-                '0x0', tx_proof, // proofs from the tree
-                sig, // concatenated signatures
-                [UTXO.block, 1000],
-                {'from': challenger, 'value': web3.toWei(0.1, 'ether')}
-            );
-
-            // The colluding parties try to respond with their invalid transaction
-            // included in block 2000, but fail.
-            sig = bob_to_charlie.sig;
-            tx_proof = tree_2000.createMerkleProof(UTXO.slot)
-            tx = bob_to_charlie.tx;
-            let challengingTxHash = alice_to_bob.leaf.hash;
-
-            assertRevert(plasma.respondChallengeBefore(
-                UTXO.slot,
-                2000,
-                challengingTxHash,
-                tx,
-                tx_proof,
-                sig,
-                {'from': elliot}
-            ));
-
-            t0 = (await web3.eth.getBlock('latest')).timestamp;
-            await increaseTimeTo( t0 + t1 + t2);
+            await increaseTimeTo(t0 + MATURITY_PERIOD + e);
             await plasma.finalizeExits({from: random_guy2});
 
             // Elliot shouldn't be able to withdraw the coin.
@@ -340,93 +388,35 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
             assert.equal(await cards.balanceOf.call(elliot), 0);
             assert.equal(await cards.balanceOf.call(plasma.address), 3);
 
-            // // On the contrary, his bond must be slashed, and `challenger` must be able to claim it
-            await txlib.withdrawBonds(plasma, challenger, 0.1);
+            // Bob is able to get both her bond and Elliot's invalid exit bond
+            await txlib.withdrawBonds(plasma, alice, 0.2);
         });
 
-        async function elliotInvalidHistoryExit(UTXO) {
+        it("Elliot makes a valid exit which gets challenged, however he responds with `respondChallengeBefore`", async function() {
+            let UTXO = {'slot': events[2]['args'].slot, 'block': events[2]['args'].blockNumber.toNumber()};
+
             let alice_to_bob = txlib.createUTXO(UTXO.slot, UTXO.block, alice, bob);
             let txs = [alice_to_bob.leaf]
             let tree_bob = await txlib.submitTransactions(authority, plasma, txs);
 
-            // The authority submits a block, but there is no transaction from Bob to Charlie
-            let tree_charlie = await txlib.submitTransactions(authority, plasma);
-
-            // Nevertheless, Charlie pretends he received the coin, and by
-            // colluding with the chain operator he is able to include his
-            // invalid transaction in a block.
-            let charlie_to_dylan = txlib.createUTXO(UTXO.slot, 2000, charlie, dylan);
-            txs = [charlie_to_dylan.leaf]
-            let tree_dylan = await txlib.submitTransactions(authority, plasma, txs);
-
-            // Dylan having received the coin, gives it to Elliot.
-            let dylan_to_elliot = txlib.createUTXO(UTXO.slot, 3000, dylan, elliot);
-            txs = [dylan_to_elliot.leaf]
-            let tree_elliot = await txlib.submitTransactions(authority, plasma, txs);
-
-            // Elliot normally should be always checking the coin's history and
-            // not accepting the payment if it's invalid like in this case, but
-            // it is considered that they are all colluding together to steal
-            // Bob's coin.  Elliot actually has all the info required to submit
-            // an exit, even if one of the transactions in the coin's history
-            // were invalid.
-            let sig = dylan_to_elliot.sig;
-
-            let prev_tx_proof = tree_dylan.createMerkleProof(UTXO.slot)
-            let exiting_tx_proof = tree_elliot.createMerkleProof(UTXO.slot)
-
-            let prev_tx = charlie_to_dylan.tx;
-            let exiting_tx = dylan_to_elliot.tx;
-
-            plasma.startExit(
-                UTXO.slot,
-                prev_tx, exiting_tx,
-                prev_tx_proof, exiting_tx_proof,
-                sig,
-                [3000, 4000],
-                {'from': elliot, 'value': web3.toWei(0.1, 'ether')}
-            );
-
-            return {'data' : alice_to_bob, 'tree': tree_bob};
-
-        }
-
-        async function elliotValidHistoryExit(UTXO) {
-            let alice_to_bob = txlib.createUTXO(UTXO.slot, UTXO.block, alice, bob);
-            let txs = [alice_to_bob.leaf]
-            let tree_bob = await txlib.submitTransactions(authority, plasma, txs);
-
-            // The authority submits a block, but there is no transaction from Bob to Charlie
             let bob_to_charlie = txlib.createUTXO(UTXO.slot, 1000, bob, charlie);
             txs = [bob_to_charlie.leaf]
             let tree_charlie = await txlib.submitTransactions(authority, plasma, txs);
 
-            // Nevertheless, Charlie pretends he received the coin, and by
-            // colluding with the chain operator he is able to include his
-            // invalid transaction in a block.
             let charlie_to_dylan = txlib.createUTXO(UTXO.slot, 2000, charlie, dylan);
             txs = [charlie_to_dylan.leaf]
             let tree_dylan = await txlib.submitTransactions(authority, plasma, txs);
 
-            // Dylan having received the coin, gives it to Elliot.
             let dylan_to_elliot = txlib.createUTXO(UTXO.slot, 3000, dylan, elliot);
             txs = [dylan_to_elliot.leaf]
             let tree_elliot = await txlib.submitTransactions(authority, plasma, txs);
 
-            // Elliot normally should be always checking the coin's history and
-            // not accepting the payment if it's invalid like in this case, but
-            // it is considered that they are all colluding together to steal
-            // Bob's coin. Elliot actually has all the info required to submit
-            // an exit, even if one of the transactions in the coin's history
-            // were invalid.
+            // Elliot exits his coin
             let sig = dylan_to_elliot.sig;
-
             let prev_tx_proof = tree_dylan.createMerkleProof(UTXO.slot)
             let exiting_tx_proof = tree_elliot.createMerkleProof(UTXO.slot)
-
             let prev_tx = charlie_to_dylan.tx;
             let exiting_tx = dylan_to_elliot.tx;
-
             plasma.startExit(
                 UTXO.slot,
                 prev_tx, exiting_tx,
@@ -435,13 +425,46 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
                 [3000, 4000],
                 {'from': elliot, 'value': web3.toWei(0.1, 'ether')}
             );
+            t0 = (await web3.eth.getBlock('latest')).timestamp;
 
-            return {
-                'bob': {'data': alice_to_bob, 'tree': tree_bob},
-                'charlie': {'data': bob_to_charlie, 'tree': tree_charlie}
-            };
+            // Invalid `challengeBefore`
+            sig = alice_to_bob.sig;
+            let proof = tree_bob.createMerkleProof(UTXO.slot)
+            prev_tx = txlib.createUTXO(UTXO.slot, 0, alice, alice).tx;
+            let tx = alice_to_bob.tx;
+            await plasma.challengeBefore(
+                UTXO.slot,
+                prev_tx , tx,
+                '0x0', proof,
+                sig,
+                [3, 1000],
+                {'from': challenger, 'value': web3.toWei(0.1, 'ether')}
+            );
 
-        }
+            // await increaseTimeTo(t0 + RESPONSE_PERIOD + e);
 
-    })
+            let challengingTxHash = alice_to_bob.leaf.hash;
+            let responseTx = bob_to_charlie.tx;
+            sig = bob_to_charlie.sig;
+            let responseProof = tree_charlie.createMerkleProof(UTXO.slot);
+            await plasma.respondChallengeBefore(
+                UTXO.slot, challengingTxHash, 2000, responseTx, responseProof, sig,
+                {'from': elliot}
+            );
+
+            await increaseTimeTo(t0 + MATURITY_PERIOD + e);
+            await plasma.finalizeExits({from: random_guy2});
+            await plasma.withdraw(UTXO.slot, {from : elliot});
+
+            assert.equal((await cards.balanceOf.call(alice)).toNumber(), 2);
+            assert.equal((await cards.balanceOf.call(bob)).toNumber(), 0);
+            assert.equal((await cards.balanceOf.call(charlie)).toNumber(), 0);
+            assert.equal((await cards.balanceOf.call(dylan)).toNumber(), 0);
+            assert.equal((await cards.balanceOf.call(elliot)).toNumber(), 1);
+            assert.equal((await cards.balanceOf.call(plasma.address)).toNumber(), 2);
+
+            // Elliot gets back his exit bond and the challenger's bond
+            await txlib.withdrawBonds(plasma, elliot, 0.2);
+        });
+    });
 });

--- a/server/test/testChallengeBefore.js
+++ b/server/test/testChallengeBefore.js
@@ -179,12 +179,13 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
                 {'from': challenger, 'value': web3.toWei(0.1, 'ether')}
             );
 
+            let challengingTxHash = alice_to_bob.leaf.hash;
             let responseTx = alice_to_bob.tx;
             sig = alice_to_bob.sig;
             let responseProof = tree_bob.createMerkleProof(UTXO.slot);
 
             assertRevert(plasma.respondChallengeBefore(
-                UTXO.slot, 1000, responseTx, responseProof, sig,
+                UTXO.slot, 1000, challengingTxHash, responseTx, responseProof, sig,
                 {'from': elliot}
             ));
 
@@ -222,12 +223,13 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
                 {'from': challenger, 'value': web3.toWei(0.1, 'ether')}
             );
 
+            let challengingTxHash = alice_to_bob.leaf.hash;
             let responseTx = bob_to_charlie.tx;
             sig = bob_to_charlie.sig;
             let responseProof = tree_charlie.createMerkleProof(UTXO.slot);
 
             await plasma.respondChallengeBefore(
-                UTXO.slot, 2000, responseTx, responseProof, sig,
+                UTXO.slot, 2000, challengingTxHash, responseTx, responseProof, sig,
                 {'from': elliot}
             );
 
@@ -312,10 +314,12 @@ contract("Plasma ERC721 - Invalid History Challenge / `challengeBefore`", async 
             sig = bob_to_charlie.sig;
             tx_proof = tree_2000.createMerkleProof(UTXO.slot)
             tx = bob_to_charlie.tx;
+            let challengingTxHash = alice_to_bob.leaf.hash;
 
             assertRevert(plasma.respondChallengeBefore(
                 UTXO.slot,
                 2000,
+                challengingTxHash,
                 tx,
                 tx_proof,
                 sig,


### PR DESCRIPTION
As @simondlr pointed out in #103:
> Additionally, if it's the case the bond should be freed, doesn't this introduce a griefing vector? Anyone can challenge any exit JUST before the challenge period is over without providing enough time to respond, resulting the exitor's bond being slash and the challenger just collecting the exitor's bond for "free"?

A possible solution to this was to additionally extend a coin's exit period by `T`, in order to allow for a response. This however introduces a potential griefing vector, by allowing an attacker to infinitely delay an exit at constant cost of the bond amount.

The solution this PR provides is the following:

Split the maturity period in 2 halves, ie if it's 7 days, in 2 x 3.5 days. All challenges must be submitted in the first 3.5 days, and all responses must be submitted before the end of the maturity period. At current design, this introduces an attack vector where the operator can submit an invalid `challengeBefore`, that can only be challenged by another transaction which is also invalid (this can happen since we consider the operator being able to add arbitrary transactions to the blocks). 

In order to mitigate that, we also need to allow for multiple challenges to exist on a coin, and also require that during finalization that the coin has 0 challenges outstanding.

This introduces an API change for `respondChallengeBefore` as the responder now also needs to provide the transaction hash that corresponds to the challenge they are responding to.

### TODO:

- [x] Split challenge period
- [x] Add multiple challenges
- [x] Modify existing truffle tests to pass
- [x] Refactor and add new truffle tests to cover functionality more extensively
- [x] Modify `loom-js` to match new functionality https://github.com/loomnetwork/loom-js/pull/72, https://github.com/loomnetwork/loom-js/pull/73
- [x] Update JS integration tests to match new functionality
- [x] Update Python integration tests to match new functionality
- [x] Update go implementation